### PR TITLE
CI: Add Java 25 support & Add proper job we can depend on

### DIFF
--- a/.github/workflows/pr-testing.yaml
+++ b/.github/workflows/pr-testing.yaml
@@ -49,9 +49,13 @@ jobs:
         timeout-minutes: 30
 
   tests:
+    if: always()
     needs:
       - pr-testing
     runs-on: ubuntu-24.04
     name: Test suite
     steps:
-      - run: echo Test suite completed
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/pr-testing.yaml
+++ b/.github/workflows/pr-testing.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['17','21']
+        version: ['17','21', '25']
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo

--- a/project.clj
+++ b/project.clj
@@ -78,12 +78,13 @@
                          ;; that sets up the JVM classpaths during installation.
                          :jvm-opts ~(let [version (System/getProperty "java.version")
                                           [major minor _] (clojure.string/split version #"\.")
-                                          unsupported-ex (ex-info "Unsupported major Java version. Expects 17 or 21."
+                                          unsupported-ex (ex-info "Unsupported major Java version. Expects 17, 21 or 25."
                                                            {:major major
                                                             :minor minor})]
                                       (condp = (java.lang.Integer/parseInt major)
                                         17 ["-Djava.security.properties==dev-resources/jdk17-fips-security"]
                                         21 ["-Djava.security.properties==dev-resources/jdk21-fips-security"]
+                                        25 ["-Djava.security.properties==dev-resources/jdk25-fips-security"]
                                         (throw unsupported-ex)))}
              :fips [:defaults :fips-deps]
              :sources-jar {:java-source-paths ^:replace []


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
