### PR TITLE
Migrate config to use trapperkeeper-webserver

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def i18n-version "1.0.4")
 (def slf4j-version "2.0.17")
 
-(defproject org.openvoxproject/http-client "2.2.9-SNAPSHOT"
+(defproject org.openvoxproject/http-client "2.3.0-SNAPSHOT"
   :description "HTTP client wrapper"
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
@@ -33,8 +33,8 @@
                          [org.openvoxproject/ssl-utils "3.6.4"]
                          [org.openvoxproject/trapperkeeper "4.3.5"]
                          [org.openvoxproject/trapperkeeper "4.3.5" :classifier "test"]
-                         [org.openvoxproject/trapperkeeper-webserver-jetty10 "1.1.8"]
-                         [org.openvoxproject/trapperkeeper-webserver-jetty10 "1.1.8" :classifier "test"]
+                         [org.openvoxproject/trapperkeeper-webserver "10.0.0"]
+                         [org.openvoxproject/trapperkeeper-webserver "10.0.0" :classifier "test"]
                          [org.slf4j/slf4j-api ~slf4j-version]
                          [org.slf4j/jul-to-slf4j ~slf4j-version]
                          [prismatic/schema "1.4.1"]]
@@ -67,8 +67,8 @@
              :dev-deps  {:dependencies [[org.bouncycastle/bcpkix-jdk18on]]}
              :dev [:defaults :dev-deps :test]
              :test {:pedantic? :warn
-                    :dependencies [[org.openvoxproject/trapperkeeper-webserver-jetty10 ]
-                                  [org.openvoxproject/trapperkeeper-webserver-jetty10 :classifier "test"]
+                    :dependencies [[org.openvoxproject/trapperkeeper-webserver]
+                                  [org.openvoxproject/trapperkeeper-webserver :classifier "test"]
                                   [org.openvoxproject/ring-middleware]]}
              :fips-deps {:dependencies [[org.bouncycastle/bcpkix-fips]
                                         [org.bouncycastle/bc-fips]

--- a/test/puppetlabs/http/client/async_plaintext_test.clj
+++ b/test/puppetlabs/http/client/async_plaintext_test.clj
@@ -6,7 +6,7 @@
             [puppetlabs.http.client.test-common :as test-common]
             [puppetlabs.i18n.core :as i18n]
             [puppetlabs.trapperkeeper.core :as tk]
-            [puppetlabs.trapperkeeper.services.webserver.jetty10-service :as jetty10]
+            [puppetlabs.trapperkeeper.services.webserver.jetty-service :as jetty]
             [puppetlabs.trapperkeeper.testutils.bootstrap :as testutils]
             [puppetlabs.trapperkeeper.testutils.logging :as testlogging]
             [puppetlabs.trapperkeeper.testutils.webserver :as testwebserver]
@@ -71,7 +71,7 @@
 (deftest persistent-async-client-test
   (testlogging/with-test-logging
     (testutils/with-app-with-config app
-      [jetty10/jetty10-service test-web-service]
+      [jetty/jetty-service test-web-service]
       {:webserver {:port 10000}}
       (testing "java async client"
         (let [request-options (RequestOptions. (URI. "http://localhost:10000/hello/"))
@@ -171,7 +171,7 @@
 (deftest java-api-cookie-test
   (testlogging/with-test-logging
     (testutils/with-app-with-config app
-      [jetty10/jetty10-service test-cookie-service]
+      [jetty/jetty-service test-cookie-service]
       {:webserver {:port 10000}}
       (let [client (Async/createClient (ClientOptions.))]
         (testing "Set a cookie using Java API"
@@ -184,7 +184,7 @@
 (deftest clj-api-cookie-test
   (testlogging/with-test-logging
     (testutils/with-app-with-config app
-      [jetty10/jetty10-service test-cookie-service]
+      [jetty/jetty-service test-cookie-service]
       {:webserver {:port 10000}}
       (let [client (async/create-client {})]
         (testing "Set a cookie using Clojure API"
@@ -197,7 +197,7 @@
 (deftest request-with-client-test
   (testlogging/with-test-logging
     (testutils/with-app-with-config app
-      [jetty10/jetty10-service test-web-service]
+      [jetty/jetty-service test-web-service]
       {:webserver {:port 10000}}
       (let [client (HttpAsyncClients/createDefault)
             opts   {:method :get :url "http://localhost:10000/hello/"}]
@@ -215,7 +215,7 @@
 (deftest query-params-test-async
   (testlogging/with-test-logging
     (testutils/with-app-with-config app
-      [jetty10/jetty10-service test-common/test-params-web-service]
+      [jetty/jetty-service test-common/test-params-web-service]
       {:webserver {:port 8080}}
       (testing "URI Query Parameters work with the Java client"
           (let [client (Async/createClient (ClientOptions.))]
@@ -324,7 +324,7 @@
                          "WWW-Authenticate", "Proxy-Authorization", "Proxy-Authenticate"}]
       (create-redirect-web-service state)
       (testutils/with-app-with-config app
-        [jetty10/jetty10-service redirect-web-service-with-state]
+        [jetty/jetty-service redirect-web-service-with-state]
         {:webserver {:hello {:port 8081} :world {:port 8082}}}
         (testing "default redirect policy does not include authorization headers"
           (let [client (Async/createClient (ClientOptions.))
@@ -449,7 +449,7 @@
 (deftest redirect-test-async
   (testlogging/with-test-logging
     (testutils/with-app-with-config app
-      [jetty10/jetty10-service test-common/redirect-web-service]
+      [jetty/jetty-service test-common/redirect-web-service]
       {:webserver {:port 8080}}
       (testing (str "redirects on POST not followed by persistent Java client "
                     "when forceRedirects option not set to true")

--- a/test/puppetlabs/http/client/metrics_test.clj
+++ b/test/puppetlabs/http/client/metrics_test.clj
@@ -6,7 +6,7 @@
             [puppetlabs.http.client.metrics :as metrics]
             [puppetlabs.http.client.sync :as sync]
             [puppetlabs.trapperkeeper.core :as tk]
-            [puppetlabs.trapperkeeper.services.webserver.jetty10-service :as jetty10]
+            [puppetlabs.trapperkeeper.services.webserver.jetty-service :as jetty]
             [puppetlabs.trapperkeeper.testutils.bootstrap :as testutils]
             [puppetlabs.trapperkeeper.testutils.logging :as testlogging]
             [puppetlabs.trapperkeeper.testutils.webserver :as testwebserver]
@@ -67,7 +67,7 @@
     (testlogging/with-test-logging
      (testutils/with-app-with-config
       app
-      [jetty10/jetty10-service test-metric-web-service]
+      [jetty/jetty-service test-metric-web-service]
       {:webserver {:port 10000}}
       (let [metric-registry (MetricRegistry.)
             hello-request-opts (RequestOptions. hello-url)
@@ -165,7 +165,7 @@
     (testlogging/with-test-logging
      (testutils/with-app-with-config
       app
-      [jetty10/jetty10-service test-metric-web-service]
+      [jetty/jetty-service test-metric-web-service]
       {:webserver {:port 10000}}
       (let [metric-registry (MetricRegistry.)]
         (with-open [client (async/create-client
@@ -253,7 +253,7 @@
     (testlogging/with-test-logging
      (testutils/with-app-with-config
       app
-      [jetty10/jetty10-service test-metric-web-service]
+      [jetty/jetty-service test-metric-web-service]
       {:webserver {:port 10000}}
       (let [metric-registry (MetricRegistry.)
             hello-request-opts (RequestOptions. hello-url)
@@ -352,7 +352,7 @@
     (testlogging/with-test-logging
      (testutils/with-app-with-config
       app
-      [jetty10/jetty10-service test-metric-web-service]
+      [jetty/jetty-service test-metric-web-service]
       {:webserver {:port 10000}}
       (let [metric-registry (MetricRegistry.)]
         (with-open [client (sync/create-client {:metric-registry metric-registry})]
@@ -630,7 +630,7 @@
     (testlogging/with-test-logging
      (testutils/with-app-with-config
       app
-      [jetty10/jetty10-service test-metric-web-service]
+      [jetty/jetty-service test-metric-web-service]
       {:webserver {:port 10000}}
       (testing "custom metric namespace works for java async client"
         (testing "metric prefix works"
@@ -744,7 +744,7 @@
   (testlogging/with-test-logging
     (testutils/with-app-with-config
      app
-     [jetty10/jetty10-service test-metric-web-service]
+     [jetty/jetty-service test-metric-web-service]
      {:webserver {:port 10000}}
      (testing "url-metrics can be disabled for clojure async client"
        (with-open [client (async/create-client {:metric-registry (MetricRegistry.)

--- a/test/puppetlabs/http/client/sync_plaintext_test.clj
+++ b/test/puppetlabs/http/client/sync_plaintext_test.clj
@@ -5,7 +5,7 @@
             [puppetlabs.http.client.sync :as sync]
             [puppetlabs.http.client.test-common :refer :all]
             [puppetlabs.trapperkeeper.core :as tk]
-            [puppetlabs.trapperkeeper.services.webserver.jetty10-service :as jetty10]
+            [puppetlabs.trapperkeeper.services.webserver.jetty-service :as jetty]
             [puppetlabs.trapperkeeper.testutils.bootstrap :as testutils]
             [puppetlabs.trapperkeeper.testutils.logging :as testlogging]
             [puppetlabs.trapperkeeper.testutils.webserver :as testwebserver]
@@ -58,7 +58,7 @@
   (testing (format "sync client: HTTP method: '%s'" http-method)
     (testlogging/with-test-logging
       (testutils/with-app-with-config app
-        [jetty10/jetty10-service test-web-service]
+        [jetty/jetty-service test-web-service]
         {:webserver {:port 10000}}
         (testing "java sync client"
           (let [request-options (SimpleRequestOptions. (URI. "http://localhost:10000/hello/"))
@@ -75,7 +75,7 @@
 (deftest sync-client-head-test
   (testlogging/with-test-logging
     (testutils/with-app-with-config app
-      [jetty10/jetty10-service test-web-service]
+      [jetty/jetty-service test-web-service]
       {:webserver {:port 10000}}
       (testing "java sync client"
         (let [request-options (SimpleRequestOptions. (URI. "http://localhost:10000/hello/"))
@@ -115,7 +115,7 @@
 (deftest sync-client-persistent-test
   (testlogging/with-test-logging
     (testutils/with-app-with-config app
-      [jetty10/jetty10-service test-web-service]
+      [jetty/jetty-service test-web-service]
       {:webserver {:port 10000}}
       (testing "persistent java client"
         (let [request-options (RequestOptions. "http://localhost:10000/hello/")
@@ -209,7 +209,7 @@
 (deftest sync-client-as-test
   (testlogging/with-test-logging
     (testutils/with-app-with-config app
-      [jetty10/jetty10-service test-web-service]
+      [jetty/jetty-service test-web-service]
       {:webserver {:port 10000}}
       (testing "java sync client: :as unspecified"
         (let [request-options (SimpleRequestOptions. (URI. "http://localhost:10000/hello/"))
@@ -250,7 +250,7 @@
 (deftest request-with-client-test
   (testlogging/with-test-logging
     (testutils/with-app-with-config app
-      [jetty10/jetty10-service test-web-service]
+      [jetty/jetty-service test-web-service]
       {:webserver {:port 10000}}
       (let [client (HttpAsyncClients/createDefault)
             opts   {:method :get :url "http://localhost:10000/hello/"}]
@@ -268,7 +268,7 @@
 (deftest java-api-cookie-test
   (testlogging/with-test-logging
     (testutils/with-app-with-config app
-      [jetty10/jetty10-service test-cookie-service]
+      [jetty/jetty-service test-cookie-service]
       {:webserver {:port 10000}}
       (let [client (Sync/createClient (ClientOptions.))]
         (testing "Set a cookie using Java API"
@@ -282,7 +282,7 @@
 (deftest clj-api-cookie-test
   (testlogging/with-test-logging
     (testutils/with-app-with-config app
-      [jetty10/jetty10-service test-cookie-service]
+      [jetty/jetty-service test-cookie-service]
       {:webserver {:port 10000}}
       (let [client (sync/create-client {})]
         (testing "Set a cookie using Clojure API"
@@ -308,7 +308,7 @@
 (deftest sync-client-request-headers-test
   (testlogging/with-test-logging
     (testutils/with-app-with-config header-app
-      [jetty10/jetty10-service test-header-web-service]
+      [jetty/jetty-service test-header-web-service]
       {:webserver {:port 10000}}
       (testing "java sync client"
         (let [request-options (-> (SimpleRequestOptions. (URI. "http://localhost:10000/hello/"))
@@ -360,7 +360,7 @@
 (deftest sync-client-request-body-test
   (testlogging/with-test-logging
     (testutils/with-app-with-config req-body-app
-      [jetty10/jetty10-service test-body-web-service]
+      [jetty/jetty-service test-body-web-service]
       {:webserver {:port 10000}}
       (testing "java sync client: string body for post request with explicit
                 content type and UTF-8 encoding uses UTF-8 encoding"
@@ -448,7 +448,7 @@
   [desc opts accept-encoding content-encoding content-should-match?]
   (testlogging/with-test-logging
     (testutils/with-app-with-config req-body-app
-      [jetty10/jetty10-service test-compression-web-service]
+      [jetty/jetty-service test-compression-web-service]
       {:webserver {:port 10000}}
       (testing (str "java sync client: compression headers / response: " desc)
         (let [request-opts (cond-> (SimpleRequestOptions. (URI. "http://localhost:10000/hello/"))
@@ -486,7 +486,7 @@
 (deftest query-params-test-sync
   (testlogging/with-test-logging
     (testutils/with-app-with-config app
-      [jetty10/jetty10-service test-params-web-service]
+      [jetty/jetty-service test-params-web-service]
       {:webserver {:port 8080}}
       (testing "URL Query Parameters work with the Java client"
         (let [request-options (SimpleRequestOptions. (URI. "http://localhost:8080/params?foo=bar&baz=lux"))
@@ -506,7 +506,7 @@
 (deftest redirect-test-sync
   (testlogging/with-test-logging
     (testutils/with-app-with-config app
-      [jetty10/jetty10-service redirect-web-service]
+      [jetty/jetty-service redirect-web-service]
       {:webserver {:port 8080}}
       (testing (str "redirects on POST not followed by Java client "
                     "when forceRedirects option not set to true")

--- a/test/puppetlabs/http/client/sync_ssl_test.clj
+++ b/test/puppetlabs/http/client/sync_ssl_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [puppetlabs.http.client.sync :as sync]
             [puppetlabs.trapperkeeper.core :as tk]
-            [puppetlabs.trapperkeeper.services.webserver.jetty10-service :as jetty10]
+            [puppetlabs.trapperkeeper.services.webserver.jetty-service :as jetty]
             [puppetlabs.trapperkeeper.testutils.bootstrap :as testutils]
             [puppetlabs.trapperkeeper.testutils.logging :as testlogging]
             [schema.test :as schema-test])
@@ -30,7 +30,7 @@
 (deftest sync-client-test-from-pems
   (testlogging/with-test-logging
     (testutils/with-app-with-config app
-      [jetty10/jetty10-service test-web-service]
+      [jetty/jetty-service test-web-service]
       {:webserver {:ssl-host    "0.0.0.0"
                    :ssl-port    10080
                    :ssl-ca-cert "./dev-resources/ssl/ca.pem"
@@ -55,7 +55,7 @@
 (deftest sync-client-test-from-ca-cert
   (testlogging/with-test-logging
     (testutils/with-app-with-config app
-      [jetty10/jetty10-service test-web-service]
+      [jetty/jetty-service test-web-service]
       {:webserver {:ssl-host    "0.0.0.0"
                    :ssl-port    10080
                    :ssl-ca-cert "./dev-resources/ssl/ca.pem"
@@ -77,7 +77,7 @@
 (deftest sync-client-test-with-invalid-ca-cert
   (testlogging/with-test-logging
     (testutils/with-app-with-config app
-      [jetty10/jetty10-service test-web-service]
+      [jetty/jetty-service test-web-service]
       {:webserver {:ssl-host    "0.0.0.0"
                    :ssl-port    10081
                    :ssl-ca-cert "./dev-resources/ssl/ca.pem"
@@ -112,7 +112,7 @@
   [server-protocols server-cipher-suites & body]
   `(testlogging/with-test-logging
     (testutils/with-app-with-config app#
-      [jetty10/jetty10-service test-web-service]
+      [jetty/jetty-service test-web-service]
       {:webserver (merge
                     {:ssl-host      "0.0.0.0"
                      :ssl-port      10080


### PR DESCRIPTION
We removed the 'Jetty10' from the repo and component name, as well as classes and service names.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
